### PR TITLE
feat: Generate authenticator urls and qr codes for secrets

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Tests
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         cfengine: ["lucee@5", "adobe@2016", "adobe@2018"]
         coldbox: ["coldbox@6"]
@@ -28,16 +28,16 @@ jobs:
       - name: Setup Java JDK
         uses: actions/setup-java@v1.4.3
         with:
-          java-version: 11 
+          java-version: 11
 
       - name: Set Up CommandBox
         uses: elpete/setup-commandbox@v1.0.0
-      
+
       - name: Install dependencies
         run: |
           box install
           box install ${{ matrix.coldbox }} --noSave
-      
+
       - name: Start server
         run: box server start cfengine=${{ matrix.cfengine }} --noSaveSettings
 
@@ -54,14 +54,14 @@ jobs:
       - name: Setup Java JDK
         uses: actions/setup-java@v1.4.3
         with:
-          java-version: 11 
+          java-version: 11
 
       - name: Set Up CommandBox
         uses: elpete/setup-commandbox@v1.0.0
-      
+
       - name: Install CFFormat
         run: box install commandbox-cfformat
-      
+
       - name: Run CFFormat
         run: box run-script format
 

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -11,7 +11,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, '__SEMANTIC RELEASE VERSION UPDATE__')"
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         cfengine: ["lucee@5", "adobe@2016", "adobe@2018"]
         coldbox: ["coldbox@6"]
@@ -22,16 +22,16 @@ jobs:
       - name: Setup Java JDK
         uses: actions/setup-java@v1.4.3
         with:
-          java-version: 11 
+          java-version: 11
 
       - name: Set Up CommandBox
         uses: elpete/setup-commandbox@v1.0.0
-      
+
       - name: Install dependencies
         run: |
           box install
           box install ${{ matrix.coldbox }} --noSave
-      
+
       - name: Start server
         run: box server start cfengine=${{ matrix.cfengine }} --noSaveSettings
 
@@ -54,17 +54,17 @@ jobs:
   #     - name: Setup Java JDK
   #       uses: actions/setup-java@v1.4.3
   #       with:
-  #         java-version: 11 
+  #         java-version: 11
 
   #     - name: Set Up CommandBox
   #       uses: elpete/setup-commandbox@v1.0.0
-      
+
   #     - name: Install and Configure Semantic Release
   #       run: |
   #         box install commandbox-semantic-release
   #         box config set endpoints.forgebox.APIToken=${{ secrets.FORGEBOX_TOKEN }}
   #         box config set modules.commandbox-semantic-release.plugins='{ "VerifyConditions": "GitHubActionsConditionsVerifier@commandbox-semantic-release", "FetchLastRelease": "ForgeBoxReleaseFetcher@commandbox-semantic-release", "RetrieveCommits": "JGitCommitsRetriever@commandbox-semantic-release", "ParseCommit": "ConventionalChangelogParser@commandbox-semantic-release", "FilterCommits": "DefaultCommitFilterer@commandbox-semantic-release", "AnalyzeCommits": "DefaultCommitAnalyzer@commandbox-semantic-release", "VerifyRelease": "NullReleaseVerifier@commandbox-semantic-release", "GenerateNotes": "GitHubMarkdownNotesGenerator@commandbox-semantic-release", "UpdateChangelog": "FileAppendChangelogUpdater@commandbox-semantic-release", "CommitArtifacts": "NullArtifactsCommitter@commandbox-semantic-release", "PublishRelease": "ForgeBoxReleasePublisher@commandbox-semantic-release", "PublicizeRelease": "GitHubReleasePublicizer@commandbox-semantic-release" }'
-      
+
       # - name: Run Semantic Release
       #   env:
       #     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, '__SEMANTIC RELEASE VERSION UPDATE__')"
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         cfengine: ["lucee@5", "adobe@2016", "adobe@2018"]
         coldbox: ["coldbox@6"]
@@ -23,16 +23,16 @@ jobs:
       - name: Setup Java JDK
         uses: actions/setup-java@v1.4.3
         with:
-          java-version: 11 
+          java-version: 11
 
       - name: Set Up CommandBox
         uses: elpete/setup-commandbox@v1.0.0
-      
+
       - name: Install dependencies
         run: |
           box install
           box install ${{ matrix.coldbox }} --noSave
-      
+
       - name: Start server
         run: box server start cfengine=${{ matrix.cfengine }} --noSaveSettings
 
@@ -55,18 +55,18 @@ jobs:
       - name: Setup Java JDK
         uses: actions/setup-java@v1.4.3
         with:
-          java-version: 11 
+          java-version: 11
 
       - name: Set Up CommandBox
         uses: elpete/setup-commandbox@v1.0.0
-      
+
       - name: Install and Configure Semantic Release
         run: |
           box install commandbox-semantic-release
           box config set endpoints.forgebox.APIToken=${{ secrets.FORGEBOX_TOKEN }}
           box config set modules.commandbox-semantic-release.targetBranch=main
           box config set modules.commandbox-semantic-release.plugins='{ "VerifyConditions": "GitHubActionsConditionsVerifier@commandbox-semantic-release", "FetchLastRelease": "ForgeBoxReleaseFetcher@commandbox-semantic-release", "RetrieveCommits": "JGitCommitsRetriever@commandbox-semantic-release", "ParseCommit": "ConventionalChangelogParser@commandbox-semantic-release", "FilterCommits": "DefaultCommitFilterer@commandbox-semantic-release", "AnalyzeCommits": "DefaultCommitAnalyzer@commandbox-semantic-release", "VerifyRelease": "NullReleaseVerifier@commandbox-semantic-release", "GenerateNotes": "GitHubMarkdownNotesGenerator@commandbox-semantic-release", "UpdateChangelog": "FileAppendChangelogUpdater@commandbox-semantic-release", "CommitArtifacts": "NullArtifactsCommitter@commandbox-semantic-release", "PublishRelease": "ForgeBoxReleasePublisher@commandbox-semantic-release", "PublicizeRelease": "GitHubReleasePublicizer@commandbox-semantic-release" }'
-      
+
       - name: Run Semantic Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Application.cfc
+++ b/Application.cfc
@@ -1,19 +1,15 @@
 component {
 
-    this.name = "TOTP Tests";
+    this.name = "TOTP Example";
     this.sessionManagement  = true;
     this.setClientCookies   = true;
     this.sessionTimeout     = createTimeSpan( 0, 0, 15, 0 );
     this.applicationTimeout = createTimeSpan( 0, 0, 15, 0 );
 
-    testsPath = getDirectoryFromPath( getCurrentTemplatePath() );
-    this.mappings[ "/tests" ] = testsPath;
-    rootPath = REReplaceNoCase( this.mappings[ "/tests" ], "tests(\\|/)", "" );
+    rootPath = getDirectoryFromPath( getCurrentTemplatePath() );
     this.mappings[ "/root" ] = rootPath;
     this.mappings[ "/totp" ] = rootPath;
     this.mappings[ "/CFzxing" ] = rootPath & "/modules/CFzxing";
-    this.mappings[ "/testingModuleRoot" ] = listDeleteAt( rootPath, listLen( rootPath, '\/' ), "\/" );
-    this.mappings[ "/testbox" ] = rootPath & "/testbox";
 
     this.javaSettings = {
         loadPaths: directoryList(

--- a/README.md
+++ b/README.md
@@ -23,6 +23,23 @@ Obtain a new instance of TOTP using WireBox or simplying by creating a new insta
 
 > WireBox/ColdBox is **NOT** required to use this module.
 
+You can view an example of using this library by viewing the `index.cfm`
+file in the root of this module.
+
+#### `generate`
+
+Generates a secret, authenticator url, and a QR code for a given email and issuer.
+The `secret` should be stored securely and associated to the user who created it.
+It is also recommended that you have the user verify a code using the secret before saving the secret.
+
+| Name   | Type    | Required | Default | Description                                                |
+| ------ | ------- | -------- | ------- | ---------------------------------------------------------- |
+| email  | string  | true     |         | The email address of the user associated with this secret. |
+| issuer | string  | true     |         | The name of the issuer of this secret.                     |
+| length | numeric | false    | 32      | The length of the secret key.                              |
+| width  | numeric | false    | 128     | The width of the QR code.                                  |
+| height | numeric | false    | 128     | The height of the QR code.                                 |
+
 #### `generateSecret`
 
 Generates a Base32 string to use as a secret key when generating and verifying TOTPs.
@@ -32,6 +49,26 @@ It is also recommended that you have the user verify a code using the secret bef
 | Name   | Type    | Required | Default | Description                   |
 | ------ | ------- | -------- | ------- | ----------------------------- |
 | length | numeric | false    | 32      | The length of the secret key. |
+
+#### `generateUrl`
+
+Generates a URL to use with authenticator apps containing the email, issuer, and generated secret key.
+
+| Name   | Type    | Required | Default | Description                                                |
+| ------ | ------- | -------- | ------- | ---------------------------------------------------------- |
+| email  | string  | true     |         | The email address of the user associated with this secret. |
+| issuer | string  | true     |         | The name of the issuer of this secret.                     |
+| length | numeric | false    | 32      | The length of the secret key.                              |
+
+#### `generateQRCode`
+
+Generates a QR Code to use with authenticator apps containing the authenticator url.
+
+| Name             | Type    | Required | Default | Description                                                                       |
+| ---------------- | ------- | -------- | ------- | --------------------------------------------------------------------------------- |
+| authenticatorUrl | string  | true     |         | The authenticator url to encode in a QR code, usually from calling `generateUrl`. |
+| width            | numeric | false    | 128     | The width of the QR code.                                                         |
+| height           | numeric | false    | 128     | The height of the QR code.                                                        |
 
 #### `generateCode`
 

--- a/box.json
+++ b/box.json
@@ -14,12 +14,15 @@
     "shortDescription":"A CFML implementation of Time-based One-time Passwords",
     "description":"A CFML implementation of Time-based One-time Passwords",
     "type":"modules",
-    "dependencies":{},
+    "dependencies":{
+        "CFzxing":"^1.0.0"
+    },
     "devDependencies":{
         "testbox":"stable"
     },
     "installPaths":{
-        "testbox":"testbox/"
+        "testbox":"testbox/",
+        "CFzxing":"modules/CFzxing/"
     },
     "scripts":{
         "format":"cfformat run ModuleConfig.cfc,models/**/*.cfc,tests/specs/**/*.cfc,tests/resources/app/handlers/**/*.cfc,tests/resources/app/config/**/*.cfc --overwrite",

--- a/box.json
+++ b/box.json
@@ -15,7 +15,7 @@
     "description":"A CFML implementation of Time-based One-time Passwords",
     "type":"modules",
     "dependencies":{
-        "CFzxing":"^1.0.0"
+        "CFzxing":"^1.1.0"
     },
     "devDependencies":{
         "testbox":"stable"

--- a/index.cfm
+++ b/index.cfm
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script src="https://cdn.tailwindcss.com?plugins=forms"></script>
+    <title>TOTP Tester</title>
+</head>
+<body class="flex flex-col justify-center items-center">
+<cfoutput>
+    <cfscript>
+        param url.email = "john@example.com";
+        param url.issuer = "Example Company";
+
+        variables.totp = new models.TOTP();
+        variables.barcodeService = new modules.CFzxing.models.Barcode();
+        variables.barcodeService.setJavaloader( { "create": function( path ) {
+            return createObject( "java", path );
+        } } );
+        variables.totp.setBarcodeService( variables.barcodeService );
+
+        if ( form.keyExists( "regenerateSecret" ) ) {
+            structDelete( application, "totpConfig" );
+        }
+        param application.totpConfig = variables.totp.generate( url.email, url.issuer, 32, 512, 512 );
+
+        param form.token = "";
+        param form.valid = true;
+        if ( form.keyExists( "validateToken" ) ) {
+            form.valid = variables.totp.verifyCode( application.totpConfig.secret, form.token );
+        }
+    </cfscript>
+
+    <h1 class="text-7xl font-bold">TOTP Example</h1>
+
+    <figure class="flex flex-col mb-4">
+        <img class="mx-auto w-64 h-64" src="data:image/png;base64,#toBase64(application.totpConfig.qrCode)#" alt="#application.totpConfig.url#" />
+        <figcaption class="text-gray-400 text-sm">#application.totpConfig.url#</figcaption>
+    </figure>
+
+    <form method="POST" class="mb-8">
+        <button type="submit" name="regenerateSecret" class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+            Regenerate Secret
+        </button>
+    </form>
+
+    <hr />
+
+    <form method="POST" class="flex">
+        <div>
+            <div class="mt-1 flex rounded-md shadow-sm">
+                <div class="relative flex items-stretch flex-grow focus-within:z-10">
+                    <input
+                        aria-label="token"
+                        type="text"
+                        name="token"
+                        id="token"
+                        value="#form.token#"
+                        inputmode="numeric"
+                        autocomplete="one-time-code"
+                        pattern="\d{6}"
+                        placeholder="Token"
+                        class="focus:ring-indigo-500 focus:border-indigo-500 block w-full rounded-none rounded-l-md sm:text-sm border-gray-300"
+                        <cfif NOT form.valid>
+                        aria-invalid="true"
+                        aria-describedby="token-error"
+                        <cfelse>
+                        aria-describedby="token-success"
+                        </cfif>
+                    >
+                </div>
+                <button type="submit" name="validateToken" class="-ml-px relative inline-flex items-center space-x-2 px-4 py-2 border border-gray-300 text-sm font-medium rounded-r-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500">
+                    <span>Validate</span>
+                </button>
+            </div>
+            <cfif NOT form.valid>
+                <p class="mt-2 text-center text-md text-red-600" id="token-error">Your token is invalid.</p>
+            <cfelse>
+                <p class="mt-2 text-center text-md text-green-600" id="token-success">Your token is valid!</p>
+            </cfif>
+        </div>
+    </form>
+</cfoutput>
+</body>
+</html>


### PR DESCRIPTION
You can now:

- Generate authenticator urls using the `generateUrl(email : string, issuer : string, secret : string) : string` method.
- Generate QR codes for authenticator urls using the `generateQRCode(authenticatorUrl : string) : Image` method
- Generate all of the required config using `generate(email : string, issuer : string) : struct` method.