### PR TITLE
ci: Move CFFormat to separate, speedy workflow

### DIFF
--- a/.github/workflows/cfformat.yml
+++ b/.github/workflows/cfformat.yml
@@ -1,0 +1,31 @@
+# .github/workflows/format.yml
+name: CFFormat
+
+on:
+  push:
+    branches-ignore:
+      - "main"
+      - "master"
+      - "development"
+  pull_request:
+    branches:
+      - main
+      - master
+      - development
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Run CFFormat
+        uses: Ortus-Solutions/commandbox-action@v1.0.2
+        with:
+          cmd: run-script format
+
+      - name: Commit Format Changes
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: "chore: Auto-format cfcs via cfformat"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -43,29 +43,3 @@ jobs:
 
       - name: Run TestBox Tests
         run: box testbox run
-
-  format:
-    runs-on: ubuntu-latest
-    name: Format
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v2
-
-      - name: Setup Java JDK
-        uses: actions/setup-java@v1.4.3
-        with:
-          java-version: 11
-
-      - name: Set Up CommandBox
-        uses: elpete/setup-commandbox@v1.0.0
-
-      - name: Install CFFormat
-        run: box install commandbox-cfformat
-
-      - name: Run CFFormat
-        run: box run-script format
-
-      - name: Commit Format Changes
-        uses: stefanzweifel/git-auto-commit-action@v4
-        with:
-          commit_message: Apply cfformat changes


### PR DESCRIPTION
Brings the CFFormat task into 2022 :calendar: 

* Drops CFFormat runtime from 1:15 to under 30s :racing_car: 
* Declutters the PR workflow :wastebasket: 
* Intros a new, simplified standalone CFFormat workflow :package: 

Example run: https://github.com/michaelborn/totp/runs/5185020861?check_suite_focus=true